### PR TITLE
Add missing handler for cookie settings button

### DIFF
--- a/cookies.html
+++ b/cookies.html
@@ -259,6 +259,7 @@
     const statusEl = document.getElementById('consent-status');
     const revokeBtn = document.getElementById('revoke-consent');
     const revokeFab = document.getElementById('revoke-fab');
+    const openSettings = document.getElementById('open-settings');
 
     // Init
     document.addEventListener('DOMContentLoaded', () => {
@@ -301,6 +302,7 @@
 
     // Controls
     btnSettings.addEventListener('click', openModal);
+    openSettings.addEventListener('click', openModal);
     modalClose.addEventListener('click', closeModal);
     revokeBtn.addEventListener('click', revokeConsent);
     revokeFab.addEventListener('click', openModal);


### PR DESCRIPTION
## Summary
- wire up the "Einstellungen öffnen" button so the cookie settings modal actually opens

## Testing
- `node - <<'NODE' ...`

------
https://chatgpt.com/codex/tasks/task_e_6896e2e72040832bb64dd49c064b77ff