### PR TITLE
refactor consent utilities and add tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/__tests__/consent.test.js
+++ b/__tests__/consent.test.js
@@ -1,0 +1,21 @@
+const { loadConsent, saveConsent, DEFAULT, LS_KEY } = require('../consent');
+
+describe('consent helpers', () => {
+  beforeEach(() => localStorage.clear());
+
+  test('loadConsent returns DEFAULT when localStorage empty', () => {
+    expect(loadConsent()).toEqual(DEFAULT);
+  });
+
+  test('loadConsent returns DEFAULT when localStorage invalid', () => {
+    localStorage.setItem(LS_KEY, '{invalid');
+    expect(loadConsent()).toEqual(DEFAULT);
+  });
+
+  test('saveConsent writes to localStorage', () => {
+    const result = saveConsent({ analytics: true });
+    const stored = JSON.parse(localStorage.getItem(LS_KEY));
+    expect(stored).toMatchObject({ analytics: true });
+    expect(result.analytics).toBe(true);
+  });
+});

--- a/consent.js
+++ b/consent.js
@@ -1,0 +1,21 @@
+const LS_KEY = "consent_v1";
+const DEFAULT = { essential: true, analytics: false, external: false, timestamp: null };
+
+function loadConsent(){
+  try {
+    const c = JSON.parse(localStorage.getItem(LS_KEY));
+    return c ? c : { ...DEFAULT };
+  } catch {
+    return { ...DEFAULT };
+  }
+}
+
+function saveConsent(next){
+  const consent = { ...loadConsent(), ...next, timestamp: new Date().toISOString() };
+  localStorage.setItem(LS_KEY, JSON.stringify(consent));
+  return consent;
+}
+
+if (typeof module !== "undefined") {
+  module.exports = { LS_KEY, DEFAULT, loadConsent, saveConsent };
+}

--- a/cookies.html
+++ b/cookies.html
@@ -229,18 +229,13 @@
     </div>
   </dialog>
 
+  <script src="consent.js"></script>
   <script>
     // ===== Consent Manager (Plain JS, ohne Dependencies) =====
-    const LS_KEY = "consent_v1";
-    const DEFAULT = { essential: true, analytics: false, external: false, timestamp: null };
     let consent = loadConsent();
 
-    function loadConsent(){
-      try{ const c = JSON.parse(localStorage.getItem(LS_KEY)); return c? c : {...DEFAULT}; }catch{ return {...DEFAULT}; }
-    }
-    function saveConsent(next){
-      consent = { ...consent, ...next, timestamp: new Date().toISOString() };
-      localStorage.setItem(LS_KEY, JSON.stringify(consent));
+    function persistConsent(next){
+      consent = saveConsent(next);
       updateUI();
       applyConsent();
     }
@@ -318,13 +313,13 @@
       toggleExternal.setAttribute('aria-pressed', String(on));
     });
 
-    btnReject.addEventListener('click', ()=> saveConsent({ analytics:false, external:false }));
-    btnAccept.addEventListener('click', ()=> saveConsent({ analytics:true, external:true }));
-    savePartial.addEventListener('click', ()=> saveConsent({
+    btnReject.addEventListener('click', ()=> persistConsent({ analytics:false, external:false }));
+    btnAccept.addEventListener('click', ()=> persistConsent({ analytics:true, external:true }));
+    savePartial.addEventListener('click', ()=> persistConsent({
       analytics: toggleAnalytics.dataset.on === 'true',
       external:  toggleExternal.dataset.on === 'true'
     }));
-    saveAll.addEventListener('click', ()=> saveConsent({ analytics:true, external:true }));
+    saveAll.addEventListener('click', ()=> persistConsent({ analytics:true, external:true }));
 
     function openModal(){ modal.showModal(); }
     function closeModal(){ modal.close(); }

--- a/package.json
+++ b/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "embed",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "jest"
+  },
+  "devDependencies": {
+    "jest": "^29.7.0"
+  }
+}


### PR DESCRIPTION
## Summary
- extract consent management helpers into reusable consent.js
- wire cookies.html to the new module
- set up Jest and add unit tests for consent helpers

## Testing
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6896e68317d0832ba548e755458c3d32