### PR TITLE
Add package metadata and mock localStorage for tests

### DIFF
--- a/__tests__/consent.test.js
+++ b/__tests__/consent.test.js
@@ -1,5 +1,20 @@
 const { loadConsent, saveConsent, DEFAULT, LS_KEY } = require('../consent');
 
+const localStorageMock = (() => {
+  let store = {};
+  return {
+    getItem: (key) => store[key] || null,
+    setItem: (key, value) => {
+      store[key] = value.toString();
+    },
+    clear: () => {
+      store = {};
+    }
+  };
+})();
+
+global.localStorage = localStorageMock;
+
 describe('consent helpers', () => {
   beforeEach(() => localStorage.clear());
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,9 @@
 {
   "name": "embed",
   "version": "1.0.0",
-  "description": "",
+  "description": "Cookie consent embed example",
+  "author": "",
+  "license": "MIT",
   "main": "index.js",
   "scripts": {
     "test": "jest"


### PR DESCRIPTION
## Summary
- provide project metadata and test script in package.json
- mock localStorage in consent tests for Node environment

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6896ed3fae14832b847d327b8979a9cd