### PR TITLE
Refine cookie banner layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -121,8 +121,8 @@
     section[id]{scroll-margin-top:calc(var(--navH,64px) + 12px)}
 
     /* Cookie Banner */
-    .cookie-modal{position:fixed;bottom:0;left:0;right:0;z-index:9999;border-top:1px solid var(--line);background:rgba(20,20,22,.96)}
-    .cookie-modal .box{display:flex;flex-wrap:wrap;align-items:center;gap:16px;max-width:1200px;margin:0 auto;padding:16px}
+    .cookie-modal{position:fixed;bottom:16px;left:50%;transform:translateX(-50%);width:calc(100% - 32px);max-width:480px;z-index:9999;border:1px solid var(--line);background:rgba(20,20,22,.96);border-radius:12px;box-shadow:0 4px 14px rgba(0,0,0,.2);font-size:14px}
+    .cookie-modal .box{display:flex;flex-wrap:wrap;align-items:center;gap:12px;padding:12px}
     .cookie-modal .actions{display:flex;gap:12px;flex-wrap:wrap;margin-left:auto}
     .cookie-modal a{color:var(--acc);text-decoration:underline}
   </style>


### PR DESCRIPTION
## Summary
- add border radius, margin and subtle shadow to cookie banner
- shrink banner font and spacing for lighter layout
- limit cookie banner width for less bulky appearance

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6896f2679168832bbd8871eb307edcb9