### PR TITLE
Ensure consent loading merges defaults

### DIFF
--- a/__tests__/consent.test.js
+++ b/__tests__/consent.test.js
@@ -27,6 +27,11 @@ describe('consent helpers', () => {
     expect(loadConsent()).toEqual(DEFAULT);
   });
 
+  test('loadConsent fills missing fields', () => {
+    localStorage.setItem(LS_KEY, JSON.stringify({ analytics: true }));
+    expect(loadConsent()).toEqual({ ...DEFAULT, analytics: true });
+  });
+
   test('saveConsent writes to localStorage', () => {
     const result = saveConsent({ analytics: true });
     const stored = JSON.parse(localStorage.getItem(LS_KEY));

--- a/consent.js
+++ b/consent.js
@@ -4,7 +4,10 @@ const DEFAULT = { essential: true, analytics: false, external: false, timestamp:
 function loadConsent(){
   try {
     const c = JSON.parse(localStorage.getItem(LS_KEY));
-    return c ? c : { ...DEFAULT };
+    if (c && typeof c === "object" && !Array.isArray(c)) {
+      return { ...DEFAULT, ...c };
+    }
+    return { ...DEFAULT };
   } catch {
     return { ...DEFAULT };
   }


### PR DESCRIPTION
## Summary
- Merge stored consent data with defaults and validate parsed type
- Add test verifying missing fields are filled

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6896fbcfbd50832bbf99bbdbb22dfb02