### PR TITLE
Add resetConsent helper and tests

### DIFF
--- a/__tests__/consent.test.js
+++ b/__tests__/consent.test.js
@@ -1,4 +1,4 @@
-const { loadConsent, saveConsent, DEFAULT, LS_KEY } = require('../consent');
+const { loadConsent, saveConsent, resetConsent, DEFAULT, LS_KEY } = require('../consent');
 
 const localStorageMock = (() => {
   let store = {};
@@ -6,6 +6,9 @@ const localStorageMock = (() => {
     getItem: (key) => store[key] || null,
     setItem: (key, value) => {
       store[key] = value.toString();
+    },
+    removeItem: (key) => {
+      delete store[key];
     },
     clear: () => {
       store = {};
@@ -32,5 +35,11 @@ describe('consent helpers', () => {
     const stored = JSON.parse(localStorage.getItem(LS_KEY));
     expect(stored).toMatchObject({ analytics: true });
     expect(result.analytics).toBe(true);
+  });
+
+  test('resetConsent removes saved consent', () => {
+    saveConsent({ analytics: true });
+    resetConsent();
+    expect(loadConsent()).toEqual(DEFAULT);
   });
 });

--- a/consent.js
+++ b/consent.js
@@ -16,6 +16,10 @@ function saveConsent(next){
   return consent;
 }
 
+function resetConsent(){
+  localStorage.removeItem(LS_KEY);
+}
+
 if (typeof module !== "undefined") {
-  module.exports = { LS_KEY, DEFAULT, loadConsent, saveConsent };
+  module.exports = { LS_KEY, DEFAULT, loadConsent, saveConsent, resetConsent };
 }


### PR DESCRIPTION
## Summary
- add resetConsent helper to clear consent from localStorage
- export resetConsent alongside existing helpers
- extend tests with resetConsent coverage and localStorage mock improvements

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6896fbd056b4832bbdb22c8a4ada6e8a