### PR TITLE
Add expiration handling for stored consent

### DIFF
--- a/consent.js
+++ b/consent.js
@@ -1,9 +1,17 @@
 const LS_KEY = "consent_v1";
 const DEFAULT = { essential: true, analytics: false, external: false, timestamp: null };
+const MAX_VALIDITY_MS = 365 * 24 * 60 * 60 * 1000;
 
 function loadConsent(){
   try {
     const c = JSON.parse(localStorage.getItem(LS_KEY));
+    if (c && c.timestamp) {
+      const age = Date.now() - new Date(c.timestamp).getTime();
+      if (age > MAX_VALIDITY_MS) {
+        localStorage.removeItem(LS_KEY);
+        return { ...DEFAULT };
+      }
+    }
     return c ? c : { ...DEFAULT };
   } catch {
     return { ...DEFAULT };
@@ -17,5 +25,5 @@ function saveConsent(next){
 }
 
 if (typeof module !== "undefined") {
-  module.exports = { LS_KEY, DEFAULT, loadConsent, saveConsent };
+  module.exports = { LS_KEY, DEFAULT, loadConsent, saveConsent, MAX_VALIDITY_MS };
 }


### PR DESCRIPTION
## Summary
- add `MAX_VALIDITY_MS` to limit consent age
- expire and remove outdated consent entries
- test expired consent falls back to defaults

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6896fbd33ea4832b9cd841d9c304743b