### PR TITLE
Return copy from loadConsent

### DIFF
--- a/__tests__/consent.test.js
+++ b/__tests__/consent.test.js
@@ -35,6 +35,14 @@ describe('consent helpers', () => {
     expect(loadConsent()).toEqual({ ...DEFAULT, analytics: true });
   });
 
+  test('mutating loadConsent result does not affect storage', () => {
+    localStorage.setItem(LS_KEY, JSON.stringify({ analytics: true }));
+    const result = loadConsent();
+    result.analytics = false;
+    const stored = JSON.parse(localStorage.getItem(LS_KEY));
+    expect(stored.analytics).toBe(true);
+  });
+
   test('saveConsent writes to localStorage', () => {
     const result = saveConsent({ analytics: true });
     const stored = JSON.parse(localStorage.getItem(LS_KEY));

--- a/consent.js
+++ b/consent.js
@@ -5,7 +5,8 @@ function loadConsent(){
   try {
     const c = JSON.parse(localStorage.getItem(LS_KEY));
     if (c && typeof c === "object" && !Array.isArray(c)) {
-      return { ...DEFAULT, ...c };
+      const merged = { ...DEFAULT, ...c };
+      return { ...merged };
     }
     return { ...DEFAULT };
   } catch {


### PR DESCRIPTION
## Summary
- ensure loadConsent returns a shallow copy of parsed consent data
- verify mutating a loaded consent object does not change stored consent

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6896fe42eac0832ba61c6da4d68fde3e