### PR TITLE
Handle consent entries missing timestamps

### DIFF
--- a/__tests__/consent.test.js
+++ b/__tests__/consent.test.js
@@ -31,8 +31,15 @@ describe('consent helpers', () => {
   });
 
   test('loadConsent fills missing fields', () => {
+    const timestamp = new Date().toISOString();
+    localStorage.setItem(LS_KEY, JSON.stringify({ analytics: true, timestamp }));
+    expect(loadConsent()).toEqual({ ...DEFAULT, analytics: true, timestamp });
+  });
+
+  test('loadConsent returns DEFAULT and clears invalid timestamp', () => {
     localStorage.setItem(LS_KEY, JSON.stringify({ analytics: true }));
-    expect(loadConsent()).toEqual({ ...DEFAULT, analytics: true });
+    expect(loadConsent()).toEqual(DEFAULT);
+    expect(localStorage.getItem(LS_KEY)).toBeNull();
   });
 
   test('saveConsent writes to localStorage', () => {

--- a/consent.js
+++ b/consent.js
@@ -5,6 +5,10 @@ function loadConsent(){
   try {
     const c = JSON.parse(localStorage.getItem(LS_KEY));
     if (c && typeof c === "object" && !Array.isArray(c)) {
+      if (!c.timestamp || Number.isNaN(Date.parse(c.timestamp))) {
+        localStorage.removeItem(LS_KEY);
+        return { ...DEFAULT };
+      }
       return { ...DEFAULT, ...c };
     }
     return { ...DEFAULT };


### PR DESCRIPTION
## Summary
- treat stored consent entries without a valid timestamp as expired and remove them
- add tests to cover missing timestamp handling and ensure storage cleanup

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6896fe45cc44832bae01cba321d46146