### PR TITLE
Validate consent object structure

### DIFF
--- a/__tests__/consent.test.js
+++ b/__tests__/consent.test.js
@@ -45,6 +45,18 @@ describe('consent helpers', () => {
     expect(loadConsent()).toEqual(DEFAULT);
   });
 
+  test('loadConsent returns DEFAULT when key types are invalid', () => {
+    const malformed = { essential: "yes", analytics: false, external: false, timestamp: null };
+    localStorage.setItem(LS_KEY, JSON.stringify(malformed));
+    expect(loadConsent()).toEqual(DEFAULT);
+  });
+
+  test('loadConsent returns DEFAULT when extra keys are present', () => {
+    const extra = { ...DEFAULT, foo: 'bar' };
+    localStorage.setItem(LS_KEY, JSON.stringify(extra));
+    expect(loadConsent()).toEqual(DEFAULT);
+  });
+
   test('saveConsent writes to localStorage', () => {
     const result = saveConsent({ analytics: true });
     const stored = JSON.parse(localStorage.getItem(LS_KEY));

--- a/consent.js
+++ b/consent.js
@@ -5,16 +5,19 @@ function loadConsent(){
   try {
     const c = JSON.parse(localStorage.getItem(LS_KEY));
     if (c && typeof c === "object" && !Array.isArray(c)) {
-      const hasKeys = ["essential", "analytics", "external", "timestamp"].every((k) =>
+      const keys = ["essential", "analytics", "external", "timestamp"];
+      const hasAllKeys = keys.every((k) =>
         Object.prototype.hasOwnProperty.call(c, k)
       );
+      const noExtraKeys = Object.keys(c).every((k) => keys.includes(k));
       const validTypes =
         typeof c.essential === "boolean" &&
         typeof c.analytics === "boolean" &&
         typeof c.external === "boolean" &&
         (typeof c.timestamp === "string" || c.timestamp === null);
-      if (hasKeys && validTypes) {
-        return { ...DEFAULT, ...c };
+      if (hasAllKeys && noExtraKeys && validTypes) {
+        const cleaned = keys.reduce((acc, k) => ({ ...acc, [k]: c[k] }), {});
+        return { ...DEFAULT, ...cleaned };
       }
     }
     return { ...DEFAULT };


### PR DESCRIPTION
## Summary
- Ensure `loadConsent` only accepts objects with all expected consent keys
- Add tests for malformed localStorage entries

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6896fe44ec48832baf9706cb010420d2