### PR TITLE
Handle consent entries missing timestamps

### DIFF
--- a/__tests__/consent.test.js
+++ b/__tests__/consent.test.js
@@ -29,10 +29,25 @@ describe('consent helpers', () => {
     localStorage.setItem(LS_KEY, '{invalid');
     expect(loadConsent()).toEqual(DEFAULT);
   });
-
   test('loadConsent fills missing fields', () => {
+    const timestamp = new Date().toISOString();
+    localStorage.setItem(LS_KEY, JSON.stringify({ analytics: true, timestamp }));
+    expect(loadConsent()).toEqual({ ...DEFAULT, analytics: true, timestamp });
+  });
+
+  test('loadConsent returns DEFAULT and clears invalid timestamp', () => {
     localStorage.setItem(LS_KEY, JSON.stringify({ analytics: true }));
-    expect(loadConsent()).toEqual({ ...DEFAULT, analytics: true });
+    expect(loadConsent()).toEqual(DEFAULT);
+    expect(localStorage.getItem(LS_KEY)).toBeNull();
+  });
+
+  test('mutating loadConsent result does not affect storage', () => {
+    const timestamp = new Date().toISOString();
+    localStorage.setItem(LS_KEY, JSON.stringify({ analytics: true, timestamp }));
+    const result = loadConsent();
+    result.analytics = false;
+    const stored = JSON.parse(localStorage.getItem(LS_KEY));
+    expect(stored.analytics).toBe(true);
   });
 
   test('saveConsent writes to localStorage', () => {

--- a/consent.js
+++ b/consent.js
@@ -5,7 +5,12 @@ function loadConsent(){
   try {
     const c = JSON.parse(localStorage.getItem(LS_KEY));
     if (c && typeof c === "object" && !Array.isArray(c)) {
-      return { ...DEFAULT, ...c };
+      if (!c.timestamp || Number.isNaN(Date.parse(c.timestamp))) {
+        localStorage.removeItem(LS_KEY);
+        return { ...DEFAULT };
+      }
+      const merged = { ...DEFAULT, ...c };
+      return { ...merged };
     }
     return { ...DEFAULT };
   } catch {


### PR DESCRIPTION
## Summary
- treat consent entries lacking a valid timestamp as expired and remove them
- add tests for missing timestamps and ensure loaded consent cannot mutate storage
- merge latest main to resolve conflicts

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6896fe45cc44832bae01cba321d46146