### PR TITLE
test: consolidate loadConsent mutation check

### DIFF
--- a/__tests__/consent.test.js
+++ b/__tests__/consent.test.js
@@ -30,11 +30,15 @@ describe('consent helpers', () => {
     expect(loadConsent()).toEqual(DEFAULT);
     expect(localStorage.getItem(LS_KEY)).toBeNull();
   });
-  test('loadConsent returns stored values when valid', () => {
+  test('loadConsent returns stored values and ignores result mutations', () => {
     const timestamp = new Date().toISOString();
     const stored = { essential: false, analytics: true, external: true, timestamp };
     localStorage.setItem(LS_KEY, JSON.stringify(stored));
-    expect(loadConsent()).toEqual(stored);
+    const result = loadConsent();
+    expect(result).toEqual(stored);
+    result.analytics = false;
+    const saved = JSON.parse(localStorage.getItem(LS_KEY));
+    expect(saved.analytics).toBe(true);
   });
 
   test('loadConsent returns DEFAULT and clears invalid timestamp', () => {
@@ -51,18 +55,6 @@ describe('consent helpers', () => {
     expect(loadConsent()).toEqual(DEFAULT);
     expect(localStorage.getItem(LS_KEY)).toBeNull();
   });
-
-  test('mutating loadConsent result does not affect storage', () => {
-    const timestamp = new Date().toISOString();
-    const stored = { essential: true, analytics: true, external: false, timestamp };
-    localStorage.setItem(LS_KEY, JSON.stringify(stored));
-    const result = loadConsent();
-    result.analytics = false;
-    const saved = JSON.parse(localStorage.getItem(LS_KEY));
-    expect(saved.analytics).toBe(true);
-  });
-
-
   test('saveConsent writes to localStorage', () => {
     const result = saveConsent({ analytics: true });
     const stored = JSON.parse(localStorage.getItem(LS_KEY));


### PR DESCRIPTION
## Summary
- ensure loadConsent returns stored values and mutations aren't persisted
- remove redundant mutation test case

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689721d5fcdc832ba56f3bc34974b966