### PR TITLE
Validate timestamp format in consent helper

### DIFF
--- a/__tests__/consent.test.js
+++ b/__tests__/consent.test.js
@@ -55,6 +55,19 @@ describe('consent helpers', () => {
     expect(loadConsent()).toEqual(DEFAULT);
     expect(localStorage.getItem(LS_KEY)).toBeNull();
   });
+  test('loadConsent removes unparseable timestamp string', () => {
+    localStorage.setItem(
+      LS_KEY,
+      JSON.stringify({
+        essential: true,
+        analytics: true,
+        external: false,
+        timestamp: 'not-a-date'
+      })
+    );
+    expect(loadConsent()).toEqual(DEFAULT);
+    expect(localStorage.getItem(LS_KEY)).toBeNull();
+  });
   test('saveConsent writes to localStorage', () => {
     const result = saveConsent({ analytics: true });
     const stored = JSON.parse(localStorage.getItem(LS_KEY));

--- a/consent.js
+++ b/consent.js
@@ -12,7 +12,9 @@ function loadConsent() {
         typeof c.essential === "boolean" &&
         typeof c.analytics === "boolean" &&
         typeof c.external === "boolean" &&
-        (typeof c.timestamp === "string" || c.timestamp === null);
+        (c.timestamp === null ||
+          (typeof c.timestamp === "string" &&
+            !Number.isNaN(Date.parse(c.timestamp))));
 
       if (hasKeys && validTypes) {
         return { ...DEFAULT, ...c };


### PR DESCRIPTION
## Summary
- ensure stored consent timestamps are parseable before acceptance
- remove stored consent when timestamp string is invalid
- cover invalid timestamp strings in tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6897237d1060832b87820b0d8611bfe4