### PR TITLE
Handle missing consent buttons

### DIFF
--- a/__tests__/embed.test.js
+++ b/__tests__/embed.test.js
@@ -1,0 +1,24 @@
+describe('embed init', () => {
+  beforeEach(() => {
+    jest.resetModules();
+
+    const fakeModal = { hidden: true, remove: jest.fn() };
+    global.document = {
+      readyState: 'complete',
+      getElementById: jest.fn((id) => {
+        if (id === 'cookie-modal') return fakeModal;
+        return null;
+      }),
+      addEventListener: jest.fn(),
+    };
+
+    global.localStorage = {
+      getItem: jest.fn(() => null),
+      setItem: jest.fn(),
+    };
+  });
+
+  test('does not throw when buttons are missing', () => {
+    expect(() => require('../embed.js')).not.toThrow();
+  });
+});

--- a/embed.js
+++ b/embed.js
@@ -22,8 +22,16 @@
       modal.remove();
     }
 
-    document.getElementById('btn-accept').addEventListener('click', () => save(true));
-    document.getElementById('btn-reject').addEventListener('click', () => save(false));
+    const accept = document.getElementById('btn-accept');
+    const reject = document.getElementById('btn-reject');
+
+    if (accept) {
+      accept.addEventListener('click', () => save(true));
+    }
+
+    if (reject) {
+      reject.addEventListener('click', () => save(false));
+    }
   }
 
   if(document.readyState === 'loading'){


### PR DESCRIPTION
## Summary
- guard cookie consent init against missing accept/reject buttons
- add unit test ensuring init doesn't throw without buttons

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689724ae323c832ba612ea3c9197f8d8