### PR TITLE
Add imprint and privacy policy pages

### DIFF
--- a/datenschutz.html
+++ b/datenschutz.html
@@ -1,0 +1,205 @@
+<!doctype html>
+<html lang="de">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Datenschutzerklärung – stanverse</title>
+  <meta name="description" content="Datenschutzerklärung der Website stanverse." />
+  <link rel="canonical" href="https://stanverse.de/datenschutz" />
+  <style>
+    /* Inter */
+    @font-face{font-family:'Inter';font-style:normal;font-weight:100 900;font-display:swap;src:url('https://rsms.me/inter/font-files/InterVariable.woff2?v=4.1') format('woff2')}
+
+    :root{--bg:#0b0b0c;--txt:#e8e8ea;--muted:#a1a1aa;--line:#232326;--acc:#8b5cf6;--acc2:#06b6d4;--r:16px;--shadow:0 10px 30px rgba(0,0,0,.35)}
+    *{box-sizing:border-box}
+    html,body{height:100%}
+    body{margin:0;font-family:Inter,system-ui,-apple-system,Segoe UI,Roboto,Helvetica Neue,Arial;color:var(--txt);background:var(--bg);padding-top:var(--navH,64px)}
+    a{color:inherit;text-decoration:none}
+    .wrap{max-width:1560px;margin:0 auto;padding:0 24px}
+    section{padding:56px 0}
+
+    /* Reveal on scroll */
+    .reveal{opacity:1;transform:none;transition:none}
+    .reveal.in{opacity:1;transform:none}
+    @media (prefers-reduced-motion: reduce){.reveal{opacity:1;transform:none;transition:none}}
+
+    /* NAV */
+    .nav{position:fixed;top:0;left:0;right:0;z-index:9999;background:rgba(11,11,12,.9);backdrop-filter:blur(8px);border-bottom:1px solid var(--line);will-change:transform,opacity;transform:translate3d(0,0,0)}
+    .nav .in{display:flex;gap:16px;align-items:center;padding:10px 24px}
+    .logo{font-weight:800;letter-spacing:-.01em}
+    .nav .links{display:flex;gap:14px;margin-left:auto;flex-wrap:wrap}
+    .nav .nav-cta{margin-left:12px;white-space:nowrap}
+    .nav .link{color:var(--muted);padding:8px 10px;border-radius:10px}
+    .nav .link:hover{color:var(--txt);background:rgba(255,255,255,.04)}
+    .btn{display:inline-flex;gap:.5rem;align-items:center;padding:12px 16px;border-radius:14px;border:1px solid #2a2a2e;background:linear-gradient(180deg, rgba(255,255,255,.06), rgba(255,255,255,.02));color:#e8e8ea;box-shadow:var(--shadow);cursor:pointer;transition:background .2s ease,transform .15s ease}
+    .btn:hover{background:linear-gradient(180deg, rgba(255,255,255,.08), rgba(255,255,255,.04));transform:scale(1.02)}
+    .btn:active{background:linear-gradient(180deg, rgba(255,255,255,.05), rgba(255,255,255,.02));transform:scale(.98)}
+    .btn.primary{background:linear-gradient(180deg, rgba(139,92,246,.28), rgba(6,182,212,.18));border-color:rgba(139,92,246,.45);color:#fff}
+    .btn.primary:hover{background:linear-gradient(180deg, rgba(139,92,246,.35), rgba(6,182,212,.23))}
+    .btn.primary:active{background:linear-gradient(180deg, rgba(139,92,246,.25), rgba(6,182,212,.15))}
+
+    /* HERO */
+    .hero{display:grid;grid-template-columns:1.2fr .8fr;gap:32px;align-items:center;position:relative;background:var(--bg) !important}.hero > *{position:relative;z-index:1}
+    .chip{display:inline-flex;gap:.5rem;align-items:center;border:1px solid var(--line);background:rgba(255,255,255,.02);padding:6px 10px;border-radius:999px;color:var(--muted);font-size:13px}
+    h1{font-weight:800;font-size:clamp(28px,5vw,52px);line-height:1.06;margin:10px 0 12px;letter-spacing:-.02em;background:linear-gradient(90deg,#ffffff 0%,#d6cfff 35%,#bdf4ff 75%);-webkit-background-clip:text;background-clip:text;color:transparent}
+    h2{font-size:clamp(22px,3vw,28px);letter-spacing:-.015em;margin:0 0 8px}
+    p.lead{color:var(--muted);margin:0 0 16px}
+    .nums{display:grid;grid-template-columns:repeat(3,minmax(0,1fr));gap:12px;margin-top:16px}
+    .num{border:1px solid var(--line);border-radius:14px;background:rgba(255,255,255,.02);padding:12px 14px;box-shadow:0 0 0 1px rgba(255,255,255,.02),0 10px 20px rgba(139,92,246,.10)}
+    .num b{font-size:18px}
+    .mock{border:1px solid var(--line);border-radius:18px;background:linear-gradient(180deg, rgba(255,255,255,.03), rgba(255,255,255,.01));padding:14px}
+    #start{padding-top:72px}
+    #leistungen{position:relative;margin-top:140px;scroll-margin-top:calc(var(--navH,64px) + 16px)}
+    @media (max-width:980px){#start{padding-top:64px}#leistungen{margin-top:100px;scroll-margin-top:calc(var(--navH,64px) + 8px)}}
+
+/* GRIDS */
+
+    .cards{display:grid;grid-template-columns:repeat(3,minmax(0,1fr));gap:16px}
+    @media (max-width: 980px){.cards{grid-template-columns:1fr}}
+    .card{border:1px solid var(--line);border-radius:16px;background:rgba(255,255,255,.02);padding:16px}
+    .card h3{margin:6px 0 6px;font-size:clamp(16px,2.2vw,20px)}
+
+    /* CASES */
+    .work{display:grid;grid-template-columns:repeat(12,1fr);gap:16px}
+    .tile{position:relative;overflow:hidden;grid-column:span 6;border:1px solid var(--line);border-radius:16px;background:#0e0f13;min-height:300px;padding:18px;display:flex;flex-direction:column}
+    .tile:nth-child(1){grid-column:span 7}
+    .tile:nth-child(2){grid-column:span 5}
+    .tile:nth-child(3){grid-column:span 12}
+    @media (max-width: 980px){.tile{grid-column:span 12}}
+    .tag{font-size:13px;color:var(--muted)}
+    .kpis{display:flex;gap:8px;flex-wrap:wrap;margin-top:6px}
+    .kpi{font-size:12px;border:1px solid var(--line);background:rgba(0,0,0,.45);padding:6px 10px;border-radius:999px}
+
+    /* Charts bottom-anchored */
+    .tile .content{display:flex;flex-direction:column;gap:6px;flex:1;position:relative;padding-bottom:170px}
+    .chartbox{position:absolute;left:0;right:0;bottom:0;height:160px;overflow-x:auto;overflow-y:hidden}
+    .chart{position:relative;height:100%;display:block;width:100%;min-width:320px}
+    .chartbox::-webkit-scrollbar{height:6px}
+    .chartbox::-webkit-scrollbar-thumb{background:#2a2a2e;border-radius:6px}
+
+    /* ASSETS */
+    .assets4{display:grid;grid-template-columns:1fr;gap:16px;margin-top:16px}
+    .asset{border:1px solid var(--line);border-radius:16px;background:rgba(255,255,255,.02);padding:14px}
+    .asset h4{margin:0 0 8px;font-size:14px;color:var(--muted);font-weight:600}
+    .asset .banner{display:block;border:1px dashed var(--line);border-radius:12px;min-height:100px;aspect-ratio:6/1;background:rgba(255,255,255,.02)}
+    .asset .thumbs{display:grid;grid-template-columns:repeat(4,1fr);gap:8px;margin-top:8px}
+    .asset .thumb{display:block;border:1px dashed var(--line);border-radius:10px;aspect-ratio:16/9;background:rgba(255,255,255,.02)}
+    .asset a:hover{outline:1px solid rgba(139,92,246,.45)}
+    @media (max-width: 700px){.asset .thumbs{grid-template-columns:repeat(2,1fr)}}
+
+    /* PROCESS */
+    .steps{display:grid;grid-template-columns:repeat(5,minmax(0,1fr));gap:12px}
+    @media (max-width: 980px){.steps{grid-template-columns:1fr 1fr}}
+    .step{border:1px solid var(--line);border-radius:14px;background:rgba(255,255,255,.02);padding:14px}
+    .step b{display:block;margin-bottom:4px}
+
+    /* FAQ */
+    details{border:1px solid var(--line);border-radius:14px;background:rgba(255,255,255,.02);padding:12px}
+    details+details{margin-top:10px}
+    summary{cursor:pointer;font-weight:600}
+
+    /* FOOTER */
+    .foot{border-top:1px solid var(--line);background:rgba(255,255,255,.02)}
+    .foot .in{display:flex;gap:12px;align-items:center;padding:14px 24px;font-size:12px}
+    .foot nav{margin-left:auto;display:flex;gap:16px}
+      /* Full‑bleed Hero Gradient (iframe‑safe) */
+    html,body{overflow-x:hidden}
+      /* Full‑bleed gradient in hero (restored) */
+    .hero{position:relative;background:var(--bg) !important}
+    .hero::before{content:"";position:absolute;top:0;bottom:0;left:calc(50% - 50vw);right:calc(50% - 50vw);pointer-events:none;z-index:0;background:
+        radial-gradient(1100px 700px at 10% -10%, rgba(139,92,246,.10), transparent 60%),
+        radial-gradient(900px 600px at 110% 10%, rgba(6,182,212,.10), transparent 60%),
+        var(--bg);
+    }
+      /* Nav fade on scroll */
+    .nav{transition: background .25s ease, opacity .25s ease, transform .28s ease, backdrop-filter .25s ease, border-color .25s ease}
+    .nav.nav-dim{opacity:.75;background:rgba(11,11,12,.62);border-bottom-color:rgba(35,35,38,.5);backdrop-filter:blur(6px)}
+    .nav.nav-hide{transform:translateY(-120%);opacity:0;pointer-events:none}
+      /* Globale Anker-Korrektur für Fixed-Header */
+    section[id]{scroll-margin-top:calc(var(--navH,64px) + 12px)}
+
+    /* Cookie Banner */
+.cookie-modal{position:fixed;bottom:24px;left:24px;width:calc(100% - 48px);max-width:420px;z-index:9999;border:1px solid var(--line);background:rgba(20,20,22,.96);border-radius:12px;box-shadow:0 4px 14px rgba(0,0,0,.2);font-size:13px;line-height:1.5}
+.cookie-modal .box{display:flex;flex-wrap:wrap;align-items:center;gap:12px;padding:10px 16px}
+.cookie-modal .actions{display:flex;gap:12px;flex-wrap:wrap;margin-left:auto}
+.cookie-modal a{color:var(--acc);text-decoration:underline}
+  </style>
+</head>
+<body>
+<nav class="nav" id="nav">
+  <div class="in wrap">
+    <a class="logo" href="/">stanverse</a>
+    <div class="links">
+      <a class="link" href="/impressum">Impressum</a>
+      <a class="link" href="/datenschutz">Datenschutz</a>
+    </div>
+  </div>
+</nav>
+<main class="wrap" id="start">
+  <section>
+    <h1>Datenschutzerklärung</h1>
+    <h2>1. Verantwortlicher</h2>
+    <p>Verantwortlich für die Datenverarbeitung auf dieser Website ist:</p>
+    <p>stanverse<br>Stan Mustermann<br>Musterstraße 1<br>12345 Musterstadt<br>E-Mail: <a href="mailto:hi@stanverse.de">hi@stanverse.de</a></p>
+    <h2>2. Erhebung und Speicherung personenbezogener Daten</h2>
+    <p>Beim Aufrufen unserer Website werden durch den auf Ihrem Endgerät zum Einsatz kommenden Browser automatisch Informationen an den Server unserer Website gesendet. Diese Informationen werden temporär in einem sogenannten Logfile gespeichert. Folgende Informationen werden dabei ohne Ihr Zutun erfasst und bis zur automatisierten Löschung gespeichert: IP-Adresse, Datum und Uhrzeit des Zugriffs, Name und URL der abgerufenen Datei, Website, von der aus der Zugriff erfolgt (Referrer-URL), verwendeter Browser und ggf. das Betriebssystem Ihres Rechners.</p>
+    <h2>3. Cookies</h2>
+    <p>Wir setzen auf unserer Website Cookies ein. Einige sind essenziell, während andere uns helfen, diese Website und Ihre Erfahrung zu verbessern. Sie können der Nutzung optionaler Cookies über das eingeblendete Banner zustimmen oder sie ablehnen.</p>
+    <h2>4. Analyse- und Drittanbieterdienste</h2>
+    <p>Sofern Sie zugestimmt haben, verwenden wir Google Analytics zur Analyse der Nutzung unserer Website. Zudem binden wir Inhalte und Dienste Dritter wie YouTube-Videos und den Terminbuchungsdienst Calendly ein. Beim Aufruf dieser Inhalte können personenbezogene Daten an die jeweiligen Anbieter übertragen werden.</p>
+    <h2>5. Ihre Rechte</h2>
+    <p>Sie haben das Recht auf Auskunft über die von uns verarbeiteten personenbezogenen Daten sowie auf Berichtigung, Löschung, Einschränkung der Verarbeitung, Widerspruch gegen die Verarbeitung und Datenübertragbarkeit. Zudem besteht ein Beschwerderecht bei einer Aufsichtsbehörde.</p>
+    <h2>6. Kontakt</h2>
+    <p>Für Fragen zum Datenschutz können Sie sich jederzeit an <a href="mailto:hi@stanverse.de">hi@stanverse.de</a> wenden.</p>
+    <p>Stand: Januar 2024</p>
+  </section>
+</main>
+<footer class="foot">
+  <div class="in wrap">
+    <div>© <span id="year"></span> stanverse</div>
+    <nav aria-label="Footerlinks" style="font-size:12px"><a href="/impressum">Impressum</a><a href="/datenschutz">Datenschutz</a><a href="https://instagram.com/stanverse" target="_blank" rel="noopener" aria-label="Instagram"><svg width="18" height="18" viewBox="0 0 24 24" fill="none"><rect x="3" y="3" width="18" height="18" rx="5" stroke="currentColor"/><circle cx="12" cy="12" r="4.5" stroke="currentColor"/><circle cx="17.5" cy="6.5" r="1.2" fill="currentColor"/></svg></a></nav>
+  </div>
+</footer>
+<div class="cookie-modal" id="cookie-modal" hidden>
+  <div class="box">
+    <strong>Cookies & Dienste</strong>
+    <p style="margin:0;color:var(--muted);flex:1">Wir verwenden essenzielle Cookies sowie – mit deiner Zustimmung – Analyse- und Medien-Cookies (z. B. Google Analytics, YouTube, Calendly). Details in der <a href="/datenschutz">Datenschutzerklärung</a>.</p>
+    <div class="actions">
+      <button class="btn" id="btn-reject">Nur essenziell</button>
+      <button class="btn primary" id="btn-accept">Alle akzeptieren</button>
+    </div>
+  </div>
+</div>
+<script>
+  (function(){
+    const nav = document.querySelector('.nav');
+    const getY = () => window.scrollY || window.pageYOffset;
+    function setNavH(){ document.documentElement.style.setProperty('--navH', nav.getBoundingClientRect().height + 'px'); }
+    setNavH();
+    window.addEventListener('resize', setNavH, {passive:true});
+    let lastY = getY();
+    let ticking = false;
+    function apply(){
+      const y = getY();
+      if(y <= 1){
+        nav.classList.remove('nav-hide','nav-dim');
+      } else if(y > lastY){
+        nav.classList.add('nav-hide','nav-dim');
+      } else if(y < lastY){
+        nav.classList.remove('nav-hide','nav-dim');
+      }
+      lastY = y;
+      ticking = false;
+    }
+    function onScroll(){ if(!ticking){ ticking = true; requestAnimationFrame(apply); } }
+    window.addEventListener('scroll', onScroll, {passive:true});
+    window.addEventListener('wheel', onScroll, {passive:true});
+    window.addEventListener('touchmove', onScroll, {passive:true});
+    setInterval(apply, 120);
+    apply();
+  })();
+  document.getElementById('year').textContent = new Date().getFullYear();
+</script>
+<script src="embed.js"></script>
+</body>
+</html>

--- a/impressum.html
+++ b/impressum.html
@@ -1,0 +1,196 @@
+<!doctype html>
+<html lang="de">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Impressum – stanverse</title>
+  <meta name="description" content="Impressum der Website stanverse." />
+  <link rel="canonical" href="https://stanverse.de/impressum" />
+  <style>
+    /* Inter */
+    @font-face{font-family:'Inter';font-style:normal;font-weight:100 900;font-display:swap;src:url('https://rsms.me/inter/font-files/InterVariable.woff2?v=4.1') format('woff2')}
+
+    :root{--bg:#0b0b0c;--txt:#e8e8ea;--muted:#a1a1aa;--line:#232326;--acc:#8b5cf6;--acc2:#06b6d4;--r:16px;--shadow:0 10px 30px rgba(0,0,0,.35)}
+    *{box-sizing:border-box}
+    html,body{height:100%}
+    body{margin:0;font-family:Inter,system-ui,-apple-system,Segoe UI,Roboto,Helvetica Neue,Arial;color:var(--txt);background:var(--bg);padding-top:var(--navH,64px)}
+    a{color:inherit;text-decoration:none}
+    .wrap{max-width:1560px;margin:0 auto;padding:0 24px}
+    section{padding:56px 0}
+
+    /* Reveal on scroll */
+    .reveal{opacity:1;transform:none;transition:none}
+    .reveal.in{opacity:1;transform:none}
+    @media (prefers-reduced-motion: reduce){.reveal{opacity:1;transform:none;transition:none}}
+
+    /* NAV */
+    .nav{position:fixed;top:0;left:0;right:0;z-index:9999;background:rgba(11,11,12,.9);backdrop-filter:blur(8px);border-bottom:1px solid var(--line);will-change:transform,opacity;transform:translate3d(0,0,0)}
+    .nav .in{display:flex;gap:16px;align-items:center;padding:10px 24px}
+    .logo{font-weight:800;letter-spacing:-.01em}
+    .nav .links{display:flex;gap:14px;margin-left:auto;flex-wrap:wrap}
+    .nav .nav-cta{margin-left:12px;white-space:nowrap}
+    .nav .link{color:var(--muted);padding:8px 10px;border-radius:10px}
+    .nav .link:hover{color:var(--txt);background:rgba(255,255,255,.04)}
+    .btn{display:inline-flex;gap:.5rem;align-items:center;padding:12px 16px;border-radius:14px;border:1px solid #2a2a2e;background:linear-gradient(180deg, rgba(255,255,255,.06), rgba(255,255,255,.02));color:#e8e8ea;box-shadow:var(--shadow);cursor:pointer;transition:background .2s ease,transform .15s ease}
+    .btn:hover{background:linear-gradient(180deg, rgba(255,255,255,.08), rgba(255,255,255,.04));transform:scale(1.02)}
+    .btn:active{background:linear-gradient(180deg, rgba(255,255,255,.05), rgba(255,255,255,.02));transform:scale(.98)}
+    .btn.primary{background:linear-gradient(180deg, rgba(139,92,246,.28), rgba(6,182,212,.18));border-color:rgba(139,92,246,.45);color:#fff}
+    .btn.primary:hover{background:linear-gradient(180deg, rgba(139,92,246,.35), rgba(6,182,212,.23))}
+    .btn.primary:active{background:linear-gradient(180deg, rgba(139,92,246,.25), rgba(6,182,212,.15))}
+
+    /* HERO */
+    .hero{display:grid;grid-template-columns:1.2fr .8fr;gap:32px;align-items:center;position:relative;background:var(--bg) !important}.hero > *{position:relative;z-index:1}
+    .chip{display:inline-flex;gap:.5rem;align-items:center;border:1px solid var(--line);background:rgba(255,255,255,.02);padding:6px 10px;border-radius:999px;color:var(--muted);font-size:13px}
+    h1{font-weight:800;font-size:clamp(28px,5vw,52px);line-height:1.06;margin:10px 0 12px;letter-spacing:-.02em;background:linear-gradient(90deg,#ffffff 0%,#d6cfff 35%,#bdf4ff 75%);-webkit-background-clip:text;background-clip:text;color:transparent}
+    h2{font-size:clamp(22px,3vw,28px);letter-spacing:-.015em;margin:0 0 8px}
+    p.lead{color:var(--muted);margin:0 0 16px}
+    .nums{display:grid;grid-template-columns:repeat(3,minmax(0,1fr));gap:12px;margin-top:16px}
+    .num{border:1px solid var(--line);border-radius:14px;background:rgba(255,255,255,.02);padding:12px 14px;box-shadow:0 0 0 1px rgba(255,255,255,.02),0 10px 20px rgba(139,92,246,.10)}
+    .num b{font-size:18px}
+    .mock{border:1px solid var(--line);border-radius:18px;background:linear-gradient(180deg, rgba(255,255,255,.03), rgba(255,255,255,.01));padding:14px}
+    #start{padding-top:72px}
+    #leistungen{position:relative;margin-top:140px;scroll-margin-top:calc(var(--navH,64px) + 16px)}
+    @media (max-width:980px){#start{padding-top:64px}#leistungen{margin-top:100px;scroll-margin-top:calc(var(--navH,64px) + 8px)}}
+
+/* GRIDS */
+
+    .cards{display:grid;grid-template-columns:repeat(3,minmax(0,1fr));gap:16px}
+    @media (max-width: 980px){.cards{grid-template-columns:1fr}}
+    .card{border:1px solid var(--line);border-radius:16px;background:rgba(255,255,255,.02);padding:16px}
+    .card h3{margin:6px 0 6px;font-size:clamp(16px,2.2vw,20px)}
+
+    /* CASES */
+    .work{display:grid;grid-template-columns:repeat(12,1fr);gap:16px}
+    .tile{position:relative;overflow:hidden;grid-column:span 6;border:1px solid var(--line);border-radius:16px;background:#0e0f13;min-height:300px;padding:18px;display:flex;flex-direction:column}
+    .tile:nth-child(1){grid-column:span 7}
+    .tile:nth-child(2){grid-column:span 5}
+    .tile:nth-child(3){grid-column:span 12}
+    @media (max-width: 980px){.tile{grid-column:span 12}}
+    .tag{font-size:13px;color:var(--muted)}
+    .kpis{display:flex;gap:8px;flex-wrap:wrap;margin-top:6px}
+    .kpi{font-size:12px;border:1px solid var(--line);background:rgba(0,0,0,.45);padding:6px 10px;border-radius:999px}
+
+    /* Charts bottom-anchored */
+    .tile .content{display:flex;flex-direction:column;gap:6px;flex:1;position:relative;padding-bottom:170px}
+    .chartbox{position:absolute;left:0;right:0;bottom:0;height:160px;overflow-x:auto;overflow-y:hidden}
+    .chart{position:relative;height:100%;display:block;width:100%;min-width:320px}
+    .chartbox::-webkit-scrollbar{height:6px}
+    .chartbox::-webkit-scrollbar-thumb{background:#2a2a2e;border-radius:6px}
+
+    /* ASSETS */
+    .assets4{display:grid;grid-template-columns:1fr;gap:16px;margin-top:16px}
+    .asset{border:1px solid var(--line);border-radius:16px;background:rgba(255,255,255,.02);padding:14px}
+    .asset h4{margin:0 0 8px;font-size:14px;color:var(--muted);font-weight:600}
+    .asset .banner{display:block;border:1px dashed var(--line);border-radius:12px;min-height:100px;aspect-ratio:6/1;background:rgba(255,255,255,.02)}
+    .asset .thumbs{display:grid;grid-template-columns:repeat(4,1fr);gap:8px;margin-top:8px}
+    .asset .thumb{display:block;border:1px dashed var(--line);border-radius:10px;aspect-ratio:16/9;background:rgba(255,255,255,.02)}
+    .asset a:hover{outline:1px solid rgba(139,92,246,.45)}
+    @media (max-width: 700px){.asset .thumbs{grid-template-columns:repeat(2,1fr)}}
+
+    /* PROCESS */
+    .steps{display:grid;grid-template-columns:repeat(5,minmax(0,1fr));gap:12px}
+    @media (max-width: 980px){.steps{grid-template-columns:1fr 1fr}}
+    .step{border:1px solid var(--line);border-radius:14px;background:rgba(255,255,255,.02);padding:14px}
+    .step b{display:block;margin-bottom:4px}
+
+    /* FAQ */
+    details{border:1px solid var(--line);border-radius:14px;background:rgba(255,255,255,.02);padding:12px}
+    details+details{margin-top:10px}
+    summary{cursor:pointer;font-weight:600}
+
+    /* FOOTER */
+    .foot{border-top:1px solid var(--line);background:rgba(255,255,255,.02)}
+    .foot .in{display:flex;gap:12px;align-items:center;padding:14px 24px;font-size:12px}
+    .foot nav{margin-left:auto;display:flex;gap:16px}
+      /* Full‑bleed Hero Gradient (iframe‑safe) */
+    html,body{overflow-x:hidden}
+      /* Full‑bleed gradient in hero (restored) */
+    .hero{position:relative;background:var(--bg) !important}
+    .hero::before{content:"";position:absolute;top:0;bottom:0;left:calc(50% - 50vw);right:calc(50% - 50vw);pointer-events:none;z-index:0;background:
+        radial-gradient(1100px 700px at 10% -10%, rgba(139,92,246,.10), transparent 60%),
+        radial-gradient(900px 600px at 110% 10%, rgba(6,182,212,.10), transparent 60%),
+        var(--bg);
+    }
+      /* Nav fade on scroll */
+    .nav{transition: background .25s ease, opacity .25s ease, transform .28s ease, backdrop-filter .25s ease, border-color .25s ease}
+    .nav.nav-dim{opacity:.75;background:rgba(11,11,12,.62);border-bottom-color:rgba(35,35,38,.5);backdrop-filter:blur(6px)}
+    .nav.nav-hide{transform:translateY(-120%);opacity:0;pointer-events:none}
+      /* Globale Anker-Korrektur für Fixed-Header */
+    section[id]{scroll-margin-top:calc(var(--navH,64px) + 12px)}
+
+    /* Cookie Banner */
+.cookie-modal{position:fixed;bottom:24px;left:24px;width:calc(100% - 48px);max-width:420px;z-index:9999;border:1px solid var(--line);background:rgba(20,20,22,.96);border-radius:12px;box-shadow:0 4px 14px rgba(0,0,0,.2);font-size:13px;line-height:1.5}
+.cookie-modal .box{display:flex;flex-wrap:wrap;align-items:center;gap:12px;padding:10px 16px}
+.cookie-modal .actions{display:flex;gap:12px;flex-wrap:wrap;margin-left:auto}
+.cookie-modal a{color:var(--acc);text-decoration:underline}
+  </style>
+</head>
+<body>
+<nav class="nav" id="nav">
+  <div class="in wrap">
+    <a class="logo" href="/">stanverse</a>
+    <div class="links">
+      <a class="link" href="/impressum">Impressum</a>
+      <a class="link" href="/datenschutz">Datenschutz</a>
+    </div>
+  </div>
+</nav>
+<main class="wrap" id="start">
+  <section>
+    <h1>Impressum</h1>
+    <p>Angaben gemäß § 5 TMG</p>
+    <p>stanverse<br>Stan Mustermann<br>Musterstraße 1<br>12345 Musterstadt</p>
+    <p>Kontakt:<br>E-Mail: <a href="mailto:hi@stanverse.de">hi@stanverse.de</a></p>
+    <p>Umsatzsteuer-ID: DE123456789</p>
+    <p>Verantwortlich für den Inhalt nach § 55 Abs. 2 RStV:<br>Stan Mustermann<br>Musterstraße 1<br>12345 Musterstadt</p>
+  </section>
+</main>
+<footer class="foot">
+  <div class="in wrap">
+    <div>© <span id="year"></span> stanverse</div>
+    <nav aria-label="Footerlinks" style="font-size:12px"><a href="/impressum">Impressum</a><a href="/datenschutz">Datenschutz</a><a href="https://instagram.com/stanverse" target="_blank" rel="noopener" aria-label="Instagram"><svg width="18" height="18" viewBox="0 0 24 24" fill="none"><rect x="3" y="3" width="18" height="18" rx="5" stroke="currentColor"/><circle cx="12" cy="12" r="4.5" stroke="currentColor"/><circle cx="17.5" cy="6.5" r="1.2" fill="currentColor"/></svg></a></nav>
+  </div>
+</footer>
+<div class="cookie-modal" id="cookie-modal" hidden>
+  <div class="box">
+    <strong>Cookies & Dienste</strong>
+    <p style="margin:0;color:var(--muted);flex:1">Wir verwenden essenzielle Cookies sowie – mit deiner Zustimmung – Analyse- und Medien-Cookies (z. B. Google Analytics, YouTube, Calendly). Details in der <a href="/datenschutz">Datenschutzerklärung</a>.</p>
+    <div class="actions">
+      <button class="btn" id="btn-reject">Nur essenziell</button>
+      <button class="btn primary" id="btn-accept">Alle akzeptieren</button>
+    </div>
+  </div>
+</div>
+<script>
+  (function(){
+    const nav = document.querySelector('.nav');
+    const getY = () => window.scrollY || window.pageYOffset;
+    function setNavH(){ document.documentElement.style.setProperty('--navH', nav.getBoundingClientRect().height + 'px'); }
+    setNavH();
+    window.addEventListener('resize', setNavH, {passive:true});
+    let lastY = getY();
+    let ticking = false;
+    function apply(){
+      const y = getY();
+      if(y <= 1){
+        nav.classList.remove('nav-hide','nav-dim');
+      } else if(y > lastY){
+        nav.classList.add('nav-hide','nav-dim');
+      } else if(y < lastY){
+        nav.classList.remove('nav-hide','nav-dim');
+      }
+      lastY = y;
+      ticking = false;
+    }
+    function onScroll(){ if(!ticking){ ticking = true; requestAnimationFrame(apply); } }
+    window.addEventListener('scroll', onScroll, {passive:true});
+    window.addEventListener('wheel', onScroll, {passive:true});
+    window.addEventListener('touchmove', onScroll, {passive:true});
+    setInterval(apply, 120);
+    apply();
+  })();
+  document.getElementById('year').textContent = new Date().getFullYear();
+</script>
+<script src="embed.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add legal imprint page matching existing site style
- add privacy policy page describing data handling, cookies, and third-party services

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6897ca1bb334832bacc59c8196cd24d6