### PR TITLE
Improve cookie modal accessibility

### DIFF
--- a/__tests__/embed.test.js
+++ b/__tests__/embed.test.js
@@ -1,8 +1,10 @@
 describe('embed init', () => {
+  let fakeModal;
+
   beforeEach(() => {
     jest.resetModules();
 
-    const fakeModal = { hidden: true, remove: jest.fn() };
+    fakeModal = { hidden: true, remove: jest.fn(), focus: jest.fn() };
     global.document = {
       readyState: 'complete',
       getElementById: jest.fn((id) => {
@@ -18,7 +20,9 @@ describe('embed init', () => {
     };
   });
 
-  test('does not throw when buttons are missing', () => {
+  test('shows and focuses modal without buttons', () => {
     expect(() => require('../embed.js')).not.toThrow();
+    expect(fakeModal.hidden).toBe(false);
+    expect(fakeModal.focus).toHaveBeenCalled();
   });
 });

--- a/embed.js
+++ b/embed.js
@@ -14,6 +14,9 @@
 
     if(!stored || !stored.timestamp){
       modal.hidden = false;
+      if (typeof modal.focus === 'function') {
+        modal.focus();
+      }
     }
 
     function save(all){

--- a/index.html
+++ b/index.html
@@ -426,9 +426,9 @@
     })();
   </script>
 
-<div class="cookie-modal" id="cookie-modal" hidden>
+<div class="cookie-modal" id="cookie-modal" hidden role="dialog" aria-modal="true" aria-labelledby="cookie-modal-title" tabindex="-1">
   <div class="box">
-    <strong>Cookies & Dienste</strong>
+    <h2 id="cookie-modal-title" style="margin:0;font-size:inherit">Cookies & Dienste</h2>
     <p style="margin:0;color:var(--muted);flex:1">Wir verwenden essenzielle Cookies sowie – mit deiner Zustimmung – Analyse- und Medien-Cookies (z. B. Google Analytics, YouTube, Calendly). Details in der <a href="/datenschutz">Datenschutzerklärung</a>.</p>
     <div class="actions">
       <button class="btn" id="btn-reject">Nur essenziell</button>


### PR DESCRIPTION
## Summary
- add dialog semantics and heading linkage to cookie modal
- focus cookie modal on display
- cover modal focus in tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689803c13504832b811ac46e564c6bdc