### PR TITLE
refactor: use consent helpers in embed

### DIFF
--- a/__tests__/embed.test.js
+++ b/__tests__/embed.test.js
@@ -17,6 +17,7 @@ describe('embed init', () => {
     global.localStorage = {
       getItem: jest.fn(() => null),
       setItem: jest.fn(),
+      removeItem: jest.fn(),
     };
   });
 
@@ -53,6 +54,7 @@ describe('embed interactions', () => {
     global.localStorage = {
       getItem: jest.fn(() => null),
       setItem: jest.fn(),
+      removeItem: jest.fn(),
     };
   });
 

--- a/embed.js
+++ b/embed.js
@@ -1,18 +1,13 @@
 (function(){
-  const { LS_KEY } = require('./consent');
+  const { loadConsent, saveConsent } = require('./consent');
 
   function init(){
     const modal = document.getElementById('cookie-modal');
     if(!modal) return;
 
-    let stored = null;
-    try {
-      stored = JSON.parse(localStorage.getItem(LS_KEY));
-    } catch {
-      // ignore parse errors
-    }
+    const consent = loadConsent();
 
-    if(!stored || !stored.timestamp){
+    if(!consent.timestamp){
       modal.hidden = false;
       if (typeof modal.focus === 'function') {
         modal.focus();
@@ -20,8 +15,7 @@
     }
 
     function save(all){
-      const data = { essential: true, analytics: all, external: all, timestamp: new Date().toISOString() };
-      localStorage.setItem(LS_KEY, JSON.stringify(data));
+      saveConsent({ analytics: all, external: all });
       modal.remove();
     }
 


### PR DESCRIPTION
## Summary
- use loadConsent and saveConsent in embed.js instead of direct localStorage access
- display consent banner when saved consent data is invalid or missing timestamp
- update tests to mock localStorage.removeItem

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689807702588832bac4c97c0ded716b1