### PR TITLE
fix: sanitize consent save input

### DIFF
--- a/__tests__/consent.test.js
+++ b/__tests__/consent.test.js
@@ -75,6 +75,14 @@ describe('consent helpers', () => {
     expect(result.analytics).toBe(true);
   });
 
+  test('saveConsent ignores non-boolean values', () => {
+    const result = saveConsent({ analytics: 'yes', external: 1 });
+    const stored = JSON.parse(localStorage.getItem(LS_KEY));
+    expect(stored).toMatchObject({ analytics: false, external: false });
+    expect(result.analytics).toBe(false);
+    expect(result.external).toBe(false);
+  });
+
   test('resetConsent removes saved consent', () => {
     saveConsent({ analytics: true });
     resetConsent();

--- a/consent.js
+++ b/consent.js
@@ -29,7 +29,18 @@ function loadConsent() {
 }
 
 function saveConsent(next) {
-  const consent = { ...loadConsent(), ...next, timestamp: new Date().toISOString() };
+  const consent = { ...loadConsent() };
+
+  if (next && typeof next === "object") {
+    if (typeof next.analytics === "boolean") {
+      consent.analytics = next.analytics;
+    }
+    if (typeof next.external === "boolean") {
+      consent.external = next.external;
+    }
+  }
+
+  consent.timestamp = new Date().toISOString();
   localStorage.setItem(LS_KEY, JSON.stringify(consent));
   return consent;
 }


### PR DESCRIPTION
## Summary
- ignore non-boolean consent values when saving
- add test ensuring saveConsent sanitizes input

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68980bb8c48c832bbddb97150f4750fa