### PR TITLE
Fix cookie banner not displaying

### DIFF
--- a/embed.js
+++ b/embed.js
@@ -1,5 +1,11 @@
 (function(){
-  const { loadConsent, saveConsent } = require('./consent');
+  // Support both CommonJS (Node/tests) and browser globals
+  let loadConsent, saveConsent;
+  if (typeof require === 'function') {
+    ({ loadConsent, saveConsent } = require('./consent'));
+  } else if (typeof window !== 'undefined') {
+    ({ loadConsent, saveConsent } = window);
+  }
 
   function init(){
     const modal = document.getElementById('cookie-modal');

--- a/index.html
+++ b/index.html
@@ -447,6 +447,7 @@
     </div>
   </div>
 </div>
+<script src="consent.js"></script>
 <script src="embed.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- load consent module in browser environment without CommonJS
- include consent script before embed for cookie banner

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68987272b404832bb58299e78241ab6e